### PR TITLE
Set frotcal to False instead of None when using "--no-frotcal"

### DIFF
--- a/cal_apriori_pang_uvfits.py
+++ b/cal_apriori_pang_uvfits.py
@@ -616,10 +616,10 @@ if __name__=='__main__':
 
 
     frotcal = True
-    if "--no-frotcal"  in sys.argv: frotcal = None
+    if "--no-frotcal"  in sys.argv: frotcal = False
 
     extrapolate = True
-    if "--no-extrapolate" in sys.argv: extrapolate = None
+    if "--no-extrapolate" in sys.argv: extrapolate = False
 
     sqrt_gains = False
     if "--sqrt_gains" in sys.argv: sqrt_gains = True


### PR DESCRIPTION
This is necessary because frotcal is directly compare to False at some
point in the code.  Moreover, keep the type of a variable is good
practice in programming anyway.